### PR TITLE
Fixed issue where publishable_key wasn't being sent to Commerce Layer

### DIFF
--- a/commercelayer/resource_stripe_gateway.go
+++ b/commercelayer/resource_stripe_gateway.go
@@ -2,6 +2,7 @@ package commercelayer
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	commercelayer "github.com/incentro-dc/go-commercelayer-sdk/api"
@@ -114,6 +115,7 @@ func resourceStripeGatewayCreateFunc(ctx context.Context, d *schema.ResourceData
 			Attributes: commercelayer.POSTStripeGateways201ResponseDataAttributes{
 				Name:            attributes["name"].(string),
 				Login:           attributes["login"].(string),
+				PublishableKey:  stringRef(attributes["publishable_key"]),
 				Reference:       stringRef(attributes["reference"]),
 				ReferenceOrigin: stringRef(attributes["reference_origin"]),
 				Metadata:        keyValueRef(attributes["metadata"]),

--- a/commercelayer/resource_stripe_gateway_test.go
+++ b/commercelayer/resource_stripe_gateway_test.go
@@ -3,6 +3,7 @@ package commercelayer
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	commercelayer "github.com/incentro-dc/go-commercelayer-sdk/api"
@@ -62,8 +63,9 @@ func testAccStripeGatewayCreate(testName string) string {
 	return hclTemplate(`
 		resource "commercelayer_stripe_gateway" "incentro_stripe_gateway" {
            attributes {
-			name        = "Incentro Stripe Gateway"
-			login       = "xxxx-yyyy-zzzz"
+			name        	= "Incentro Stripe Gateway"
+			login       	= "xxxx-yyyy-zzzz"
+			publishable_key = "aaaa-bbbb-cccc"
 
 			metadata = {
 				foo: "bar"
@@ -78,8 +80,9 @@ func testAccStripeGatewayUpdate(testName string) string {
 	return hclTemplate(`
 		resource "commercelayer_stripe_gateway" "incentro_stripe_gateway" {
            attributes {
-			name        = "Incentro Stripe Gateway Changed"
-			login       = "xxxx-yyyy-zzzz"
+			name        	= "Incentro Stripe Gateway Changed"
+			login       	= "xxxx-yyyy-zzzz"
+			publishable_key = "aaaa-bbbb-cccc"
 
 			metadata = {
 				bar: "foo"


### PR DESCRIPTION
### Issue

When creating a Stripe payment gateway, the publishable_key was not populated.

### Expected

When creating a Stripe payment gateway, the publishable_key is populated when specified in the `commercelayer_stripe_gateway`

e.g.

```
resource "commercelayer_stripe_gateway" "stripe_gateway_2" {
  attributes {
    reference       = "stripe_payment_gateway_2"
    name            = "Ashiba Stripe Gateway 2"
    login           = var.stripe_gateway_login
    publishable_key = var.stripe_gateway_publishable_key
  }
}
```